### PR TITLE
feat: support config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,13 @@ Then just add the types to `tsconfig.json`:
 
 After that, every time you make a change to any routes in `routes/` This plugin will auto generate your route types for
 Ziggy's `route()` to auto complete for you.
+
+### Configuration
+
+This plugin allows you to set the following configuration:
+
+| key    | description                       | required | default                                 |
+| ------ | --------------------------------- | -------- | --------------------------------------- |
+| path   | The path to output the types file | `NO`     | `node_modules/vite-plugin-ziggy/routes` |
+| only   | Include _ONLY_ these routes       | `NO`     | `[]`                                    |
+| except | All routes _EXCEPT_ these         | `NO`     | `[]`                                    |

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,27 @@
 import { Plugin } from 'vite';
 import { run } from 'vite-plugin-run';
 
-export type Config = {};
+export type Config = {
+  path?: string;
+  only?: string[];
+  except?: string[];
+};
 
-export default (config?: Config): Plugin => {
+export default ({ path = 'node_modules/vite-plugin-ziggy/routes', only = [], except = [] }: Config = {}): Plugin => {
+  const cmd = ['php', 'artisan', 'ziggy:generate', path, '--types-only'];
+
+  if (only.length) {
+    cmd.push('--only', only.join(','));
+  }
+
+  if (except.length) {
+    cmd.push('--except', except.join(','));
+  }
+
   const { configResolved, handleHotUpdate } = run([
     {
       name: 'ziggy-generator',
-      run: ['php', 'artisan', 'ziggy:generate', 'node_modules/vite-plugin-ziggy/routes', '--types-only'],
+      run: cmd,
       condition: (file) => file.includes('/routes/') && file.endsWith('.php'),
     },
   ]);


### PR DESCRIPTION
This adds support for configuring ziggy under the hood directly from the Vite plugin.

Depends on https://github.com/tighten/ziggy/pull/805 being merged and published.