### PR TITLE
Pull Request: Improve Ziggy Plugin with Version Detection & Customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ import ziggy from 'vite-plugin-ziggy';
 export default defineConfig({
   plugins: [
     ...
-    ziggyPlugin({
+    ziggy({
       sail: true, // Uses Sail instead of PHP
       group: 'api',
       url: 'http://laravel-app.test',

--- a/README.md
+++ b/README.md
@@ -16,10 +16,16 @@ import { defineConfig } from 'vite';
 import ziggy from 'vite-plugin-ziggy';
 
 export default defineConfig({
-    plugins: [
-        ...
-        ziggy(),
-    ],
+  plugins: [
+    ...
+    ziggyPlugin({
+      sail: true, // Uses Sail instead of PHP
+      group: 'api',
+      url: 'http://laravel-app.test',
+      only: ['admin.*'],
+      except: ['debugbar.*'],
+    }),
+  ],
 });
 ```
 
@@ -44,8 +50,13 @@ Ziggy's `route()` to auto complete for you.
 
 This plugin allows you to set the following configuration:
 
-| key    | description                       | required | default                                 |
-| ------ | --------------------------------- | -------- | --------------------------------------- |
-| path   | The path to output the types file | `NO`     | `node_modules/vite-plugin-ziggy/routes` |
-| only   | Include _ONLY_ these routes       | `NO`     | `[]`                                    |
-| except | All routes _EXCEPT_ these         | `NO`     | `[]`                                    |
+| Key         | Description                                     | Required | Default                                 |
+| ----------- | ----------------------------------------------- | -------- | --------------------------------------- |
+| `path`      | The path to output the types file               | ❌ No    | `node_modules/vite-plugin-ziggy/routes` |
+| `only`      | Include _ONLY_ these routes                     | ❌ No    | `[]`                                    |
+| `except`    | All routes _EXCEPT_ these                       | ❌ No    | `[]`                                    |
+| `sail`      | Use `sail` instead of the `php` command         | ❌ No    | `false`                                 |
+| `group`     | Route group to generate                         | ❌ No    | `undefined` (not set by default)        |
+| `url`       | The application URL                             | ❌ No    | `undefined` (not set by default)        |
+| `types`     | Generate TypeScript declaration file            | ❌ No    | `true`                                  |
+| `typesOnly` | Generate _only_ the TypeScript declaration file | ❌ No    | `true`                                  |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-ziggy",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Vite plugin for Ziggy",
   "keywords": [
     "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-ziggy",
-  "version": "0.3.0",
+  "version": "0.2.0",
   "description": "Vite plugin for Ziggy",
   "keywords": [
     "vite",
@@ -9,12 +9,24 @@
   ],
   "type": "module",
   "exports": {
-    ".": {
-      "default": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+    "./build": {
+      "default": "./dist/build.js",
+      "types": "./dist/build.d.ts"
+    },
+    "./config": {
+      "default": "./dist/config.js",
+      "types": "./dist/config.d.ts"
+    },
+    "./utils": {
+      "default": "./dist/utils.js",
+      "types": "./dist/utils.d.ts"
     },
     "./routes": {
       "types": "./routes.d.ts"
+    },
+    ".": {
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@aniftyco/prettier": "^0.1.0",
+    "@types/node": "^22.13.1",
     "prettier": "^3.3.3",
     "typescript": "^5.2.2",
     "vite": "^5.3.4"

--- a/src/build.ts
+++ b/src/build.ts
@@ -1,0 +1,25 @@
+import { Config } from './config.js';
+
+export type BuildConfig = Required<Omit<Config, 'url' | 'group'>> & {
+  url?: string;
+  group?: string;
+};
+
+export const build = (version: string, config: BuildConfig): string[] => {
+  const cmd = [config.sail && !process.env.LARAVEL_SAIL ? 'sail' : 'php', 'artisan', 'ziggy:generate', config.path];
+
+  if (config.group) cmd.push('--group', config.group);
+  if (config.url) cmd.push('--url', config.url);
+
+  if (['1', '2'].includes(version)) {
+    if (config.types) cmd.push('--types');
+    if (config.typesOnly) cmd.push('--types-only');
+
+    if (version === '2') {
+      if (config.only.length > 0) cmd.push('--only', config.only.join(','));
+      if (config.except.length > 0) cmd.push('--except', config.except.join(','));
+    }
+  }
+
+  return cmd;
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,59 @@
+/**
+ * Options for configuring the Ziggy plugin.
+ */
+export type Config = {
+  /**
+   * Path to the generated JavaScript/TypeScript file.
+   * @default 'node_modules/vite-plugin-ziggy/routes'
+   */
+  path?: string;
+
+  /**
+   * Whether to use `sail` instead of the `php` command.
+   * @default false
+   */
+  sail?: boolean;
+
+  /**
+   * Route group to generate.
+   */
+  group?: string;
+
+  /**
+   * Application URL.
+   */
+  url?: string;
+
+  /**
+   * Generate TypeScript declaration file.
+   * @default true
+   */
+  types?: boolean;
+
+  /**
+   * Generate only the TypeScript declaration file.
+   * @default true
+   */
+  typesOnly?: boolean;
+
+  /**
+   * Route name patterns to include.
+   * @default []
+   */
+  only?: string[];
+
+  /**
+   * Route name patterns to exclude.
+   * @default []
+   */
+  except?: string[];
+};
+
+export const defaultConfig: Config = {
+  path: 'node_modules/vite-plugin-ziggy/routes',
+  sail: false,
+  types: true,
+  typesOnly: true,
+  only: [],
+  except: [],
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,6 @@ export type Config = {
 };
 
 const ZIGGY_PACKAGE_NAME = 'tightenco/ziggy';
-const SUPPORTED_VERSIONS = ['1', '2'];
 
 function getComposerPackageVersion(): string {
   try {
@@ -78,12 +77,6 @@ function getComposerPackageVersion(): string {
     }
 
     const majorVersion = match[1];
-    if (!SUPPORTED_VERSIONS.includes(majorVersion)) {
-      throw new Error(
-        `Unsupported Ziggy version: ${majorVersion}. Supported versions: ${SUPPORTED_VERSIONS.join(', ')}`,
-      );
-    }
-
     return majorVersion;
   } catch (error) {
     if (
@@ -113,7 +106,7 @@ function buildCommand(
   if (config.group) cmd.push('--group', config.group);
   if (config.url) cmd.push('--url', config.url);
 
-  if (SUPPORTED_VERSIONS.includes(version)) {
+  if (['1', '2'].includes(version)) {
     if (config.types) cmd.push('--types');
     if (config.typesOnly) cmd.push('--types-only');
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,28 +1,152 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
 import { Plugin } from 'vite';
 import { run } from 'vite-plugin-run';
 
+/**
+ * Options for configuring the Ziggy plugin.
+ */
 export type Config = {
+  /**
+   * Path to the generated JavaScript/TypeScript file.
+   * @default 'node_modules/vite-plugin-ziggy/routes'
+   */
   path?: string;
+
+  /**
+   * Whether to use `sail` instead of the `php` command.
+   * @default false
+   */
+  sail?: boolean;
+
+  /**
+   * Route group to generate.
+   */
+  group?: string;
+
+  /**
+   * Application URL.
+   */
+  url?: string;
+
+  /**
+   * Generate TypeScript declaration file.
+   * @default true
+   */
+  types?: boolean;
+
+  /**
+   * Generate only the TypeScript declaration file.
+   * @default true
+   */
+  typesOnly?: boolean;
+
+  /**
+   * Route name patterns to include.
+   * @default []
+   */
   only?: string[];
+
+  /**
+   * Route name patterns to exclude.
+   * @default []
+   */
   except?: string[];
 };
 
-export default ({ path = 'node_modules/vite-plugin-ziggy/routes', only = [], except = [] }: Config = {}): Plugin => {
-  const cmd = ['php', 'artisan', 'ziggy:generate', path, '--types-only'];
+const ZIGGY_PACKAGE_NAME = 'tightenco/ziggy';
+const SUPPORTED_VERSIONS = ['1', '2'];
 
-  if (only.length) {
-    cmd.push('--only', only.join(','));
+function getComposerPackageVersion(): string {
+  try {
+    const composerPath = resolve(process.cwd(), 'composer.json');
+    const composer = JSON.parse(readFileSync(composerPath, 'utf-8'));
+
+    if (!composer.require?.[ZIGGY_PACKAGE_NAME]) {
+      throw new Error(
+        `${ZIGGY_PACKAGE_NAME} not found in composer.json dependencies`,
+      );
+    }
+
+    const version = composer.require[ZIGGY_PACKAGE_NAME];
+    const match = version.match(/^[~^><]?(\d+)/);
+
+    if (!match) {
+      throw new Error(
+        `Invalid version format for ${ZIGGY_PACKAGE_NAME}: ${version}`,
+      );
+    }
+
+    const majorVersion = match[1];
+    if (!SUPPORTED_VERSIONS.includes(majorVersion)) {
+      throw new Error(
+        `Unsupported Ziggy version: ${majorVersion}. Supported versions: ${SUPPORTED_VERSIONS.join(', ')}`,
+      );
+    }
+
+    return majorVersion;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      (error as NodeJS.ErrnoException).code === 'ENOENT'
+    ) {
+      throw new Error('composer.json not found in project root');
+    }
+    throw error;
+  }
+}
+
+function buildCommand(
+  version: string,
+  config: Required<Omit<Config, 'url' | 'group'>> & {
+    url?: string;
+    group?: string;
+  },
+): string[] {
+  const cmd = [
+    config.sail ? 'sail' : 'php',
+    'artisan',
+    'ziggy:generate',
+    config.path,
+  ];
+
+  if (config.group) cmd.push('--group', config.group);
+  if (config.url) cmd.push('--url', config.url);
+
+  if (SUPPORTED_VERSIONS.includes(version)) {
+    if (config.types) cmd.push('--types');
+    if (config.typesOnly) cmd.push('--types-only');
+
+    if (version === '2') {
+      if (config.only.length > 0)
+        cmd.push('--only', config.only.join(','));
+      if (config.except.length > 0)
+        cmd.push('--except', config.except.join(','));
+    }
   }
 
-  if (except.length) {
-    cmd.push('--except', except.join(','));
-  }
+  return cmd;
+}
+
+export default (config: Config = {}): Plugin => {
+  const defaultConfig = {
+    path: 'node_modules/vite-plugin-ziggy/routess',
+    sail: false,
+    types: true,
+    typesOnly: true,
+    only: [],
+    except: [],
+  };
+
+  const version = getComposerPackageVersion();
+  const cmd = buildCommand(version, { ...defaultConfig, ...config });
 
   const { configResolved, handleHotUpdate } = run([
     {
       name: 'ziggy-generator',
       run: cmd,
-      condition: (file) => file.includes('/routes/') && file.endsWith('.php'),
+      condition: (file) =>
+        file.includes('/routes/') && file.endsWith('.php'),
     },
   ]);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ function buildCommand(
   },
 ): string[] {
   const cmd = [
-    config.sail ? 'sail' : 'php',
+    config.sail && !process.env.LARAVEL_SAIL ? 'sail' : 'php',
     'artisan',
     'ziggy:generate',
     config.path,
@@ -148,6 +148,7 @@ export default (config: Config = {}): Plugin => {
         run: cmd,
         condition: (file) =>
           file.includes('/routes/') && file.endsWith('.php'),
+        
       },
     ]);
     return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,21 +138,35 @@ export default (config: Config = {}): Plugin => {
     except: [],
   };
 
-  const version = getComposerPackageVersion();
-  const cmd = buildCommand(version, { ...defaultConfig, ...config });
+  try {
+    const version = getComposerPackageVersion();
+    const cmd = buildCommand(version, { ...defaultConfig, ...config });
 
-  const { configResolved, handleHotUpdate } = run([
-    {
-      name: 'ziggy-generator',
-      run: cmd,
-      condition: (file) =>
-        file.includes('/routes/') && file.endsWith('.php'),
-    },
-  ]);
+    const { configResolved, handleHotUpdate } = run([
+      {
+        name: 'ziggy-generator',
+        run: cmd,
+        condition: (file) =>
+          file.includes('/routes/') && file.endsWith('.php'),
+      },
+    ]);
+    return {
+      name: 'ziggy-plugin',
+      configResolved,
+      handleHotUpdate,
+    };
+  } catch (error) {
+    console.error('\n[vite-plugin-ziggy] Error:');
+    if (error instanceof Error) {
+      console.error(error.message);
+      if (process.env.NODE_ENV === 'development') {
+        console.error(error.stack);
+      }
+    } else {
+      throw error;
+    }
+  }
 
-  return {
-    name: 'ziggy-plugin',
-    configResolved,
-    handleHotUpdate,
-  };
+  return {} as Plugin;
+
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+export const ZIGGY_PACKAGE_NAME = 'tightenco/ziggy';
+
+export const getComposerPackageVersion = (): string => {
+  try {
+    const composerPath = resolve(process.cwd(), 'composer.json');
+    const composer = JSON.parse(readFileSync(composerPath, 'utf-8'));
+
+    if (!composer.require?.[ZIGGY_PACKAGE_NAME]) {
+      throw new Error(`${ZIGGY_PACKAGE_NAME} not found in composer.json dependencies`);
+    }
+
+    const version = composer.require[ZIGGY_PACKAGE_NAME];
+    const match = version.match(/^[~^><]?(\d+)/);
+
+    if (!match) {
+      throw new Error(`Invalid version format for ${ZIGGY_PACKAGE_NAME}: ${version}`);
+    }
+
+    return match[1];
+  } catch (error) {
+    if (error instanceof Error && (error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error('composer.json not found in project root');
+    }
+
+    throw error;
+  }
+};


### PR DESCRIPTION
This is my first-ever pull request to open source. I’m excited to contribute after seeing your Twitter post about this package. My goal was to enhance customizability while maintaining backward compatibility with other Ziggy versions. I may have overengineered it a bit, but I’d love your feedback!  

---

## **✨ Summary**  

This PR enhances the **Vite Ziggy plugin** by:  

- **Automatically detecting `tightenco/ziggy` version** via `composer.json`.  
- **Adding Laravel Sail support** (`sail` option).  
- **Introducing more customization options** (`group`, `url`, `types`, `typesOnly`).  
- **Improving error handling and logging**.  
- **Refactoring for better maintainability**.  

---

## **🔧 Changes Introduced**  

### ✅ **Ziggy Version Detection**  

- Implemented `getComposerPackageVersion()`, which:  
  - Reads `composer.json` to determine the installed Ziggy version.  
  - Extracts the **major version number**.  

### ✅ **New Configuration Options**  

- **`sail`** (default: `false`) → Uses `sail` instead of `php`.  
- **`group`** (optional) → Adds the `--group` flag.  
- **`url`** (optional) → Adds the `--url` flag.  
- **`types` / `typesOnly`** (default: `true`) → Enables TypeScript options dynamically.  
- **`only` / `except`** → Now conditionally included **only in Ziggy v2+**.  
